### PR TITLE
Bump MudBlazor and PublishSPAforGitHubPages.Build (#19)

### DIFF
--- a/src/MinimalistVideo/MinimalistVideo.csproj
+++ b/src/MinimalistVideo/MinimalistVideo.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
   <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
   <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
-    <PackageReference Include="MudBlazor" Version="8.6.0" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
-    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.0" />
+    <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />
     <PackageReference Include="ValueOf" Version="2.0.31" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps MudBlazor from 8.6.0 to 8.12.0
Bumps PublishSPAforGitHubPages.Build from 3.0.0 to 3.0.1

---
updated-dependencies:
- dependency-name: MudBlazor dependency-version: 8.12.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license
- dependency-name: PublishSPAforGitHubPages.Build dependency-version: 3.0.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license ...