### PR TITLE
Bump the open-source-license group with 4 updates

### DIFF
--- a/src/MinimalistVideo/MinimalistVideo.csproj
+++ b/src/MinimalistVideo/MinimalistVideo.csproj
@@ -17,11 +17,11 @@
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="BlazorWasmPreRendering.Build" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
-  <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
-  <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
+  <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.9" />
+  <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.9" />
     <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.1" />


### PR DESCRIPTION
Bumps Microsoft.AspNetCore.Components.WebAssembly from 9.0.8 to 9.0.9 Bumps Microsoft.AspNetCore.Components.WebAssembly.DevServer from 9.0.8 to 9.0.9 Bumps Microsoft.NET.ILLink.Tasks from 9.0.8 to 9.0.9 Bumps Microsoft.NET.Sdk.WebAssembly.Pack from 9.0.8 to 9.0.9

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Components.WebAssembly dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.AspNetCore.Components.WebAssembly.DevServer dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.NET.ILLink.Tasks dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license
- dependency-name: Microsoft.NET.Sdk.WebAssembly.Pack dependency-version: 9.0.9 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: open-source-license ...